### PR TITLE
Add email automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# email_automation
+# Email Automation
+
+This repository provides a small script to send an initial email and up to three follow-ups based on an Excel spreadsheet.
+
+## Usage
+1. Prepare an Excel file called `contacts.xlsx` in the repository root with the following columns:
+   - `Nombre`: recipient name.
+   - `Empresa`: company name.
+   - `Email`: email address.
+
+2. Ensure you have Python installed with the packages from `requirements.txt`.
+
+3. Define the SMTP credentials as environment variables:
+   - `SMTP_SERVER`
+   - `SMTP_PORT`
+   - `SMTP_USER`
+   - `SMTP_PASSWORD`
+   - `FROM_ADDRESS`
+
+4. Run the script:
+
+```bash
+python send_emails.py
+```
+
+The script sends the first email with `presentation.pdf` attached and then sends three follow-ups every five minutes.

--- a/presentation.pdf
+++ b/presentation.pdf
@@ -1,0 +1,1 @@
+This is the presentation attachment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+openpyxl

--- a/send_emails.py
+++ b/send_emails.py
@@ -1,0 +1,90 @@
+import os
+import time
+import pandas as pd
+import smtplib
+from email.message import EmailMessage
+
+TEMPLATE_DIR = 'templates'
+ATTACHMENT = 'presentation.pdf'
+CONTACT_FILE = 'contacts.xlsx'
+SMTP_SERVER = os.environ.get('SMTP_SERVER', 'smtp.example.com')
+SMTP_PORT = int(os.environ.get('SMTP_PORT', '587'))
+SMTP_USER = os.environ.get('SMTP_USER', 'user@example.com')
+SMTP_PASSWORD = os.environ.get('SMTP_PASSWORD', 'password')
+FROM_ADDRESS = os.environ.get('FROM_ADDRESS', 'jaime.valero@example.com')
+
+
+def load_template(name: str) -> str:
+    path = os.path.join(TEMPLATE_DIR, name)
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+INITIAL_TEMPLATE = load_template('initial.txt')
+FOLLOW1_TEMPLATE = load_template('follow1.txt')
+FOLLOW2_TEMPLATE = load_template('follow2.txt')
+FOLLOW3_TEMPLATE = load_template('follow3.txt')
+
+
+def fill_template(template: str, nombre: str, empresa: str) -> str:
+    return (
+        template
+        .replace('[Nombre]', nombre)
+        .replace('[Persona]', nombre)
+        .replace('[Empresa]', empresa)
+    )
+
+
+def send_email(to_address: str, subject: str, body: str, attachment: str | None = None) -> None:
+    msg = EmailMessage()
+    msg['Subject'] = subject
+    msg['From'] = FROM_ADDRESS
+    msg['To'] = to_address
+    msg.set_content(body)
+
+    if attachment:
+        with open(attachment, 'rb') as f:
+            data = f.read()
+            filename = os.path.basename(attachment)
+            msg.add_attachment(data, maintype='application', subtype='octet-stream', filename=filename)
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+        server.starttls()
+        server.login(SMTP_USER, SMTP_PASSWORD)
+        server.send_message(msg)
+
+
+def load_contacts(path: str) -> list[dict]:
+    df = pd.read_excel(path)
+    contacts = []
+    for _, row in df.iterrows():
+        contacts.append({'nombre': row['Nombre'], 'empresa': row['Empresa'], 'email': row['Email']})
+    return contacts
+
+
+def send_initial_emails(contacts: list[dict]) -> None:
+    for c in contacts:
+        body = fill_template(INITIAL_TEMPLATE, c['nombre'], c['empresa'])
+        subject = f"Propuesta estratégica para {c['empresa']}"
+        send_email(c['email'], subject, body, ATTACHMENT)
+
+
+def send_followup_emails(contacts: list[dict], template: str) -> None:
+    for c in contacts:
+        body = fill_template(template, c['nombre'], c['empresa'])
+        subject = f"Seguimiento de propuesta para {c['empresa']}"
+        send_email(c['email'], subject, body)
+
+
+def main() -> None:
+    contacts = load_contacts(CONTACT_FILE)
+    send_initial_emails(contacts)
+
+    for idx, template in enumerate([FOLLOW1_TEMPLATE, FOLLOW2_TEMPLATE, FOLLOW3_TEMPLATE], start=1):
+        time.sleep(5 * 60)  # wait 5 minutes
+        send_followup_emails(contacts, template)
+        print(f"Follow-up {idx} sent")
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/follow1.txt
+++ b/templates/follow1.txt
@@ -1,0 +1,12 @@
+Estimado [Nombre],
+
+Le escribo para darle seguimiento a mi anterior correo y reiterar mi interés en poder conversar con usted.
+
+Sigo con atención la evolución de [Empresa] y el dinamismo del sector en el que opera. Por ello, me gustaría proponerle una reunión, sin compromiso y con total confidencialidad, para presentarle brevemente Livingstone Partners, compartir impresiones sobre el mercado y explorar posibles alternativas estratégicas que puedan resultar de interés para su empresa.
+
+En Livingstone contamos con una sólida trayectoria acompañando a compañías en momentos clave de su desarrollo, con un enfoque muy práctico y orientado a crear valor.
+
+Quedo a su disposición para coordinar una fecha que le resulte cómoda.
+ 
+Un saludo,
+Jaime Valero.

--- a/templates/follow2.txt
+++ b/templates/follow2.txt
@@ -1,0 +1,14 @@
+Estimado [Nombre],
+
+Espero que se encuentre bien. Le escribo una vez más porque estamos viendo un interés creciente de inversores —tanto fondos como grupos industriales— por compañías como [Empresa], y creemos que podrían valorar muy positivamente una oportunidad como la suya.
+
+El mercado actual sigue mostrando una fuerte liquidez y apetito por activos bien posicionados, especialmente en sectores con perspectivas de crecimiento como el suyo. En este contexto, creemos que [Empresa] podría estar en una posición óptima para aprovechar este ciclo favorable y explorar alternativas estratégicas con alto potencial de valor.
+
+Desde Livingstone, seguimos muy de cerca a compañías como la suya y acompañamos a sus equipos en procesos diseñados a medida, siempre con absoluta confidencialidad y sin compromiso alguno en esta primera etapa.
+
+¿Le parece si coordinamos una breve llamada para comentar con más detalle la posibilidad de una operación corporativa?
+
+Quedo atento a su respuesta.
+
+Un saludo,
+Jaime Valero.

--- a/templates/follow3.txt
+++ b/templates/follow3.txt
@@ -1,0 +1,10 @@
+Estimado [Nombre],
+
+Disculpe mi insistencia.
+
+Le contacto porque estamos en contacto con inversores activos en su sector y hemos percibido interés por valorar una operación corporativa con [Empresa]. ¿Cree que tendría sentido explorar esta oportunidad?
+
+Quedo atento a su respuesta.
+
+Un saludo,
+Jaime Valero.

--- a/templates/initial.txt
+++ b/templates/initial.txt
@@ -1,0 +1,22 @@
+Buenas tardes [Persona],
+ 
+Soy Jaime Valero, Director en Livingstone Partners, una firma internacional especializada en asesoramiento en operaciones corporativas, como compraventa de empresas y ampliaciones de capital. Con más de 1.000 transacciones a nivel global, nuestro enfoque es diseñar soluciones a medida que aporten valor real en procesos complejos. Adjunto nuestra presentación corporativa para que pueda conocer más sobre nuestra trayectoria y experiencia.
+ 
+He seguido con interés el crecimiento de [Empresa] y el dinamismo del sector en el que opera. Me gustaría proponerle una reunión, sin compromiso y con total confidencialidad, para presentarle nuestra firma, compartir impresiones de mercado y explorar alternativas estratégicas que podrían ser de interés para su empresa.
+ 
+Quería destacar que actualmente existen inversores con un alto interés en adquisiciones dentro de su sector. La abundante liquidez en los mercados y el apetito inversor hacen de este un momento especialmente favorable para plantear operaciones corporativas. Desde Livingstone, contamos con una amplia experiencia en el sector Alimentación en España, habiendo asesorado en operaciones como:
+• Compra minoritaria de Solina en Eurocebollas.
+• Compra de Caffé Corsini por parte de Melitta.
+• Venta de V. Ros a Iberian Premium Fruits.
+• Fusión de Frutas Tono con Guillem Export.
+• Venta minoritaria de Eurocebollas a Nazca.
+• Venta mayoritaria de Distribuciones Juan Luna a Nazca.
+• Venta de un secadero de jamón de Grupo Osborne a Incarlopsa.
+• Venta de Chocolates Trapa a Lacasa.
+• Venta de Aceitunas Guadalquivir a Alantra PE.
+ 
+Encantado de reunirnos en sus oficinas o, si lo prefiere, organizar una videollamada en el horario que mejor le convenga.
+Quedo a la espera de su disponibilidad para concretar una fecha.
+ 
+Un saludo,
+Jaime Valero.


### PR DESCRIPTION
## Summary
- add templates for initial mail and follow-ups
- create automation script to send mails and schedule follow-ups
- document usage and SMTP environment vars
- add requirements list and placeholder attachment

## Testing
- `python -m py_compile send_emails.py`

------
https://chatgpt.com/codex/tasks/task_e_6847e60f66ac8322952a4a1d90f37e11